### PR TITLE
Fix relativizer order

### DIFF
--- a/lib/roger/release.rb
+++ b/lib/roger/release.rb
@@ -277,8 +277,11 @@ module Roger
       end
 
       unless @stack.find{|(processor, options)| processor.class == Roger::Release::Processors::Mockup }
-        @stack.push([Roger::Release::Processors::UrlRelativizer.new, relativizer_options])
         @stack.unshift([Roger::Release::Processors::Mockup.new, mockup_options])
+      end
+
+      unless @stack.find{|(processor, options)| processor.class == Roger::Release::Processors::UrlRelativizer }
+        @stack.push([Roger::Release::Processors::UrlRelativizer.new, relativizer_options])
       end
     end
 


### PR DESCRIPTION
So, basically this fixed https://github.com/DigitPaint/roger/issues/3, running the relativizer as last. 

Different paths can be taken, for me this seems to most sane and safest approach. As basically every HTML link to an preprocessed asset does not yet exist when relativizer is ran and hence not relativized. As I've seen this also break for production code, I think this change is better than making it configurable, which it already is when `r.use(:mockup)` is used. 

While I could merge this myself, I think it is good when @flurin takes a look at this, guessing he can answer the question: are there reasons why relativizer should be run **before** other processors?

I need to rebase this commit to master, however also waiting for fix-gh-pages to be reviewed and merged. 
