### PR TITLE
Make sure the module constant exists

### DIFF
--- a/lib/roger/cli/generate.rb
+++ b/lib/roger/cli/generate.rb
@@ -1,5 +1,5 @@
-module Roger
-  class Cli::Generate < Thor
+module Roger::Cli
+  class Generate < Thor
     def self.exit_on_failure?
       true
     end


### PR DESCRIPTION
Without this change when making a generator in module outside of roger, an error will be thrown: uninitialized constant Roger::Cli (NameError)

This can be fixed when [in the module](https://github.com/hkrutzer/roger_scsslinter/blob/master/lib/roger_scsslinter/generator.rb#L4-L6) with:

	# <- hekje
	module Roger
	  module Cli; end
	end

This doesn't really feel intuitive.