### PR TITLE
Create test for verbosity options

### DIFF
--- a/test/unit/cli/cli_test_test.rb
+++ b/test/unit/cli/cli_test_test.rb
@@ -66,7 +66,17 @@ module Roger
 
     # roger test -v
     def test_has_option_v
-      out, err = run_test_command %w{test -v}
+      # A somewhat a-typical test,
+      # just to make it work
+      cli = ::Roger::Cli::Base.new [], %w{--verbose}
+      cli.class.project.mockupfile.test do |t|
+        t.use :noop
+      end
+
+      out, _err = capture do
+        cli.invoke "test"
+      end
+
       assert_includes out, "NOOP DEBUG", out
     end
 


### PR DESCRIPTION
This pull request make the failing test that was added in https://github.com/DigitPaint/roger/issues/12,
pass again. So the issue is that we rely on the Project to hold the passed class options,
this however is not the case for the helpers which initiliaze their own project.
What I did now is, I create a Cli::Base manualy and pass a --verbose on init time.
After I added my tests, I invoke this initialised CLI. Which passes the --verbose
to Project in its initialized, which is skipped in the helpers.

I guess we could redesign the helpers, seperate it as it tests several
concerns or just don't test it at all. For now, I've added this one, for your consideration.
It is however safe to merge, imo.