### PR TITLE
Fix yielding in content_for partials

### DIFF
--- a/test/unit/template_test.rb
+++ b/test/unit/template_test.rb
@@ -135,6 +135,11 @@ module Roger
       assert_equal template.render, "BA"
     end    
 
+    def test_content_for_yield_with_partial_with_block
+      template = Template.new("---\nlayout: \"yield\"\n---\nB<% content_for :one do %><% partial 'test/yield' do %>CONTENT<% end %><% end %>A", @config.update(:source_path => @base + "html/test.html.erb"))
+      assert_equal template.render, "BAB-CONTENT-A"
+    end
+
     # Environment
 
     def test_template_env


### PR DESCRIPTION
When partials were used that yielded their given block,
the variable in which was yielded was reused due to their nesting.
By supplying a counter, and thus making the yielded _to_ variable unique
we no longer have duplicated content.