### PR TITLE
Setup test coverage with integration to code climate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 pkg/*
 Gemfile.lock
+coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,6 @@ before_script:
   - git config --global user.name "Travis-CI"
 matrix:
   fast_finish: true
+env:
+  global:
+    secure: eMPdp74VWvC6r7CSzN06FEMf5Wq9AfxqIgjfr4Z4AMxUsehApSJe1y/blaqN6XcpLK4TYw4bwzRUjAzUjOMMW5aJ4Kr1nrW2k6bJehbubhkkPfDxcc+NzYUZ+oxqbPMOZP6zQoSRRd5rhY2qd3xVkKecK1KZOxlA1/pce6y15YU=

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,5 @@ source "https://rubygems.org"
 gemspec name: "roger"
 
 gem "rake"
+# Only coverage support in CI, CODECLIMATE TOKEN is part of travis.yml
+gem "codeclimate-test-reporter", group: :test, require: nil if ENV["CODECLIMATE_REPO_TOKEN"]

--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ task :rubocop do
 end
 
 Rake::TestTask.new do |t|
-  t.libs << "test"
+  t.libs << "test/unit"
   t.test_files = FileList["test/unit/**/*_test.rb"]
-  t.verbose = true
+  t.verbose = false
 end

--- a/roger.gemspec
+++ b/roger.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency("test-unit", "~> 3.0.0")
   s.add_development_dependency("mocha", "~> 1.1.0")
+  s.add_development_dependency("simplecov", "~> 0.10.0")
   s.add_development_dependency("puma", "~> 2.10.0")
-  s.add_development_dependency "rubocop", "~> 0.31.0"
+  s.add_development_dependency("rubocop", "~> 0.31.0")
 end

--- a/test/unit/cli/cli_base_test.rb
+++ b/test/unit/cli/cli_base_test.rb
@@ -1,5 +1,5 @@
-require "./lib/roger/cli.rb"
-require "test/unit"
+require "test_helper"
+require "./lib/roger/cli"
 
 module Roger
   # Test for roger base commands

--- a/test/unit/cli/cli_generate_test.rb
+++ b/test/unit/cli/cli_generate_test.rb
@@ -1,5 +1,5 @@
-require "./lib/roger/cli.rb"
-require "test/unit"
+require "test_helper"
+require "./lib/roger/cli"
 
 require File.dirname(__FILE__) + "/../../helpers/cli"
 

--- a/test/unit/cli/cli_serve_test.rb
+++ b/test/unit/cli/cli_serve_test.rb
@@ -1,5 +1,5 @@
-require "./lib/roger/cli.rb"
-require "test/unit"
+require "test_helper"
+require "./lib/roger/cli"
 
 require File.dirname(__FILE__) + "/../../helpers/cli"
 

--- a/test/unit/cli/cli_test_test.rb
+++ b/test/unit/cli/cli_test_test.rb
@@ -1,5 +1,5 @@
-require "./lib/roger/cli.rb"
-require "test/unit"
+require "test_helper"
+require "./lib/roger/cli"
 
 require File.dirname(__FILE__) + "/../../helpers/cli"
 

--- a/test/unit/cli/cli_version_test.rb
+++ b/test/unit/cli/cli_version_test.rb
@@ -1,5 +1,5 @@
-require "./lib/roger/cli.rb"
-require "test/unit"
+require "test_helper"
+require "./lib/roger/cli"
 
 require File.dirname(__FILE__) + "/../../helpers/cli"
 

--- a/test/unit/generators_test.rb
+++ b/test/unit/generators_test.rb
@@ -1,6 +1,6 @@
 # Generators register themself on the CLI module
+require "test_helper"
 require "./lib/roger/generators.rb"
-require "test/unit"
 
 module CustomGens
   module Generators

--- a/test/unit/helpers/logging_test.rb
+++ b/test/unit/helpers/logging_test.rb
@@ -1,6 +1,5 @@
+require "test_helper"
 require "./lib/roger/helpers/logging"
-require "test/unit"
-require File.dirname(__FILE__) + "/../../helpers/cli"
 
 # Empty logging class
 class MyLogger

--- a/test/unit/rack/roger_test.rb
+++ b/test/unit/rack/roger_test.rb
@@ -1,4 +1,4 @@
-require "test/unit"
+require "test_helper"
 require File.dirname(__FILE__) + "../../../../lib/roger/rack/roger"
 
 module Roger

--- a/test/unit/release/cleaner_test.rb
+++ b/test/unit/release/cleaner_test.rb
@@ -1,6 +1,6 @@
-require "./lib/roger/release.rb"
-require "./lib/roger/release/cleaner.rb"
-require "test/unit"
+require "test_helper"
+require "./lib/roger/release"
+require "./lib/roger/release/cleaner"
 
 # Test Roger Cleaner
 class CleanerTest < ::Test::Unit::TestCase

--- a/test/unit/release/finalizers/git_branch_test.rb
+++ b/test/unit/release/finalizers/git_branch_test.rb
@@ -1,6 +1,5 @@
-require "./lib/roger/release/finalizers/git_branch.rb"
-require "test/unit"
-require "mocha/test_unit"
+require "test_helper"
+require "./lib/roger/release/finalizers/git_branch"
 require "tmpdir"
 
 # Test for Roger GitBranchFinalizer

--- a/test/unit/release/finalizers/zip_test.rb
+++ b/test/unit/release/finalizers/zip_test.rb
@@ -1,5 +1,5 @@
+require "test_helper"
 require "./lib/roger/release/finalizers/zip"
-require "test/unit"
 require "mocha/test_unit"
 require "tmpdir"
 

--- a/test/unit/release/mockup_test.rb
+++ b/test/unit/release/mockup_test.rb
@@ -1,6 +1,5 @@
-require "./lib/roger/release.rb"
-require "./lib/roger/release.rb"
-require "test/unit"
+require "test_helper"
+require "./lib/roger/release"
 
 # Test Roger Mockup
 class MockupTest < ::Test::Unit::TestCase

--- a/test/unit/release/processors_test.rb
+++ b/test/unit/release/processors_test.rb
@@ -1,5 +1,5 @@
-require "./lib/roger/release.rb"
-require "test/unit"
+require "test_helper"
+require "./lib/roger/release"
 
 # Test Roger processors
 class ProcessorsTest < ::Test::Unit::TestCase

--- a/test/unit/release_test.rb
+++ b/test/unit/release_test.rb
@@ -1,6 +1,6 @@
 # Generators register themself on the CLI module
+require "test_helper"
 require "./lib/roger/release.rb"
-require "test/unit"
 
 module Roger
   # Test Roger Release

--- a/test/unit/resolver_test.rb
+++ b/test/unit/resolver_test.rb
@@ -1,6 +1,6 @@
 # Generators register themself on the CLI module
+require "test_helper"
 require "./lib/roger/resolver.rb"
-require "test/unit"
 
 module Roger
   # Test Roger resolver

--- a/test/unit/server_test.rb
+++ b/test/unit/server_test.rb
@@ -1,4 +1,4 @@
-require "test/unit"
+require "test_helper"
 require File.dirname(__FILE__) + "../../../lib/roger/rack/roger"
 
 module Roger

--- a/test/unit/template_test.rb
+++ b/test/unit/template_test.rb
@@ -1,7 +1,7 @@
 # encoding: UTF-8
 # Generators register themself on the CLI module
+require "test_helper"
 require "./lib/roger/template.rb"
-require "test/unit"
 
 module Roger
   # Roger template tests

--- a/test/unit/test_helper.rb
+++ b/test/unit/test_helper.rb
@@ -1,3 +1,11 @@
+if ENV["CODECLIMATE_REPO_TOKEN"]
+  require "codeclimate-test-reporter"
+  CodeClimate::TestReporter.start
+else
+  require "simplecov"
+  SimpleCov.start
+end
+
 require "test/unit"
 require "mocha/test_unit"
 

--- a/test/unit/test_helper.rb
+++ b/test/unit/test_helper.rb
@@ -1,0 +1,4 @@
+require "test/unit"
+require "mocha/test_unit"
+
+require File.dirname(__FILE__) + "/../helpers/cli"

--- a/test/unit/test_test.rb
+++ b/test/unit/test_test.rb
@@ -1,6 +1,5 @@
 # encoding: UTF-8
-require "test/unit"
-require "mocha/test_unit"
+require "test_helper"
 require "./lib/roger/test.rb"
 
 module Roger


### PR DESCRIPTION
For this to work I extracted all test_unit/mocha/helpers requires
to one file, this one gets required in all the test nows, for here we
can start the test coverage.

We are using code_climate when ENV["CODECLIMATE_REPO_TOKEN"] is set,
because when running code_climate during development it will also push
coverage which is less optimal.