### PR TITLE
Add support for fixed SCM

### DIFF
--- a/lib/roger/release.rb
+++ b/lib/roger/release.rb
@@ -25,7 +25,7 @@ module Roger
      end
     end
 
-    # @option config [Symbol] :scm The SCM to use (default = :git)
+    # @option config [:git, :fixed] :scm The SCM to use (default = :git)
     # @option config [String, Pathname] :target_path The path/directory to put the release into
     # @option config [String, Pathname]:build_path Temporary path used to build the release
     # @option config [Boolean] :cleanup_build Wether or not to remove the build_path after we're
@@ -84,6 +84,8 @@ module Roger
       case config[:scm]
       when :git
         @_scm = Release::Scm::Git.new(path: source_path)
+      when :fixed
+        @_scm = Release::Scm::Fixed.new
       else
         fail "Unknown SCM #{options[:scm].inspect}"
       end

--- a/lib/roger/release/scm.rb
+++ b/lib/roger/release/scm.rb
@@ -33,3 +33,4 @@ module Roger
 end
 
 require File.dirname(__FILE__) + "/scm/git"
+require File.dirname(__FILE__) + "/scm/fixed"

--- a/lib/roger/release/scm/fixed.rb
+++ b/lib/roger/release/scm/fixed.rb
@@ -1,0 +1,22 @@
+module Roger
+  class Release
+    module Scm
+      # The Fixed SCM implementation for Roger release
+      # Here you define everything in the config or set it later with the different accessors.
+      class Fixed < Base
+        attr_accessor :version, :date, :previous
+
+        # @option config [String] :version Version to use (default "0.0.0")
+        # @option config [Time] :date Date to use (default Time.now)
+        # @option config [String] :previous Previous version to use (default "0.0.0")
+        def initialize(config = {})
+          super(config)
+
+          self.version = config[:version] || "0.0.0"
+          self.date = config[:date] || Time.now
+          self.previous = config[:previous] || "0.0.0"
+        end
+      end
+    end
+  end
+end

--- a/test/unit/release/scm/fixed_test.rb
+++ b/test/unit/release/scm/fixed_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+require "mocha/test_unit"
+
+module Roger
+  # Test for Roger Zip finalizer
+  class FixedScmTest < ::Test::Unit::TestCase
+    def setup
+      @scm = Roger::Release::Scm::Fixed.new
+    end
+
+    def test_implements_scm_interfase
+      assert @scm.respond_to?(:version)
+      assert @scm.respond_to?(:date)
+      assert @scm.respond_to?(:previous)
+    end
+
+    def test_has_defaults
+      assert_equal "0.0.0", @scm.version
+      assert_equal "0.0.0", @scm.previous
+      assert @scm.date
+    end
+
+    def test_input_equals_output
+      assert_equal "0.0.0", @scm.version
+      @scm.version = "1"
+      assert_equal "1", @scm.version
+    end
+  end
+end


### PR DESCRIPTION
This can be used in tests as you can specify what
version you want outputted. This is much better
than having to stub it in tests.