### PR TITLE
Use Mock objects for release and project

### DIFF
--- a/lib/roger/testing/mock_project.rb
+++ b/lib/roger/testing/mock_project.rb
@@ -1,0 +1,43 @@
+require "test_construct"
+
+module Roger
+  module Testing
+    # A Mock project. If initialized without a path it will
+    # create a test_construct with the following (empty) paths:
+    #
+    # - html
+    # - partials
+    # - layouts
+    # - releases
+    #
+    # Use MockProject in testing but never forget to call:
+    #
+    #     MockProject#destroy
+    #
+    # in teardown otherwise you pollute your filesystem with build directories
+    class MockProject < Project
+      include TestConstruct::Helpers
+
+      attr_accessor :construct
+
+      def initialize(path = nil, config = {})
+        unless path
+          self.construct = setup_construct
+          path = construct
+
+          %w(html partials layouts releases).each do |dir|
+            construct.directory dir
+          end
+        end
+
+        # Call super to initialize
+        super(path, config)
+      end
+
+      # Destroy will remove all files/directories
+      def destroy
+        teardown_construct(construct) if construct
+      end
+    end
+  end
+end

--- a/lib/roger/testing/mock_release.rb
+++ b/lib/roger/testing/mock_release.rb
@@ -1,0 +1,39 @@
+require File.dirname(__FILE__) + "/mock_project"
+
+module Roger
+  module Testing
+    # Creates a mock release object. It is the same as a regular release
+    # with the following "presets"
+    #
+    # - it will automatically use the :fixed SCM
+    # - it will automatically initialize a MockProject if you don't
+    #   pass a project to the initializer
+    #
+    # Use MockRelease in testing but never forget to call:
+    #
+    #     MockRelease#destroy
+    #
+    # in teardown otherwise you pollute your filesystem with build directories
+    #
+    class MockRelease < Release
+      def initialize(project = nil, config = {})
+        config = {
+          scm: :fixed
+        }.update(config)
+
+        unless project
+          # Create a mock project that's completely empty
+          project = MockProject.new
+        end
+
+        # Call super to initialize
+        super(project, config)
+      end
+
+      # Destroy will remove all files/directories
+      def destroy
+        project.destroy if project.is_a?(MockProject)
+      end
+    end
+  end
+end

--- a/roger.gemspec
+++ b/roger.gemspec
@@ -42,4 +42,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency("simplecov", "~> 0.10.0")
   s.add_development_dependency("puma", "~> 2.10.0")
   s.add_development_dependency("rubocop", "~> 0.31.0")
+  s.add_development_dependency("test_construct", "~> 2.0")
 end

--- a/test/unit/release/cleaner_test.rb
+++ b/test/unit/release/cleaner_test.rb
@@ -1,45 +1,50 @@
 require "test_helper"
-require "./lib/roger/release"
-require "./lib/roger/release/cleaner"
+require "roger/testing/mock_release"
 
 module Roger
   # Test Roger Cleaner
   class CleanerTest < ::Test::Unit::TestCase
     def setup
-      @base = File.dirname(__FILE__) + "/../../project"
+      @release = Testing::MockRelease.new
+    end
+
+    def teardown
+      @release.destroy
+      @release = nil
     end
 
     def test_use_array_as_pattern
       dirs = %w(dir1 dir2)
 
-      create_and_assert_directories(dirs)
-
-      project = Roger::Project.new(@base)
-      release = Roger::Release.new(project, build_path: Pathname.new(@base))
+      dirs.each do |dir|
+        @release.project.construct.directory "build/#{dir}"
+      end
 
       cleaner = Roger::Release::Cleaner.new(dirs)
-      cleaner.call(release)
+      cleaner.call(@release)
 
       dirs.each do |dir|
-        path = @base + "/" + dir
+        path = @release.build_path + dir
         assert(!File.directory?(path))
       end
     end
 
     def test_only_clean_inside_build_path_relative
-      cleaner = Roger::Release::Cleaner.new(@base)
-      inside_build_path = cleaner.send :inside_build_path?, @base, @base + "/html/formats"
+      project_path = @release.project.path
+      cleaner = Roger::Release::Cleaner.new(project_path)
+      inside = cleaner.send :inside_build_path?, project_path, project_path + "html"
 
-      assert(inside_build_path, "Only delete content inside build_path")
+      assert(inside, "Only delete content inside build_path")
     end
 
     def test_only_clean_inside_build_path_absolute
-      path = Pathname.new(@base).realpath.to_s
+      project_path = @release.project.path
+      path = Pathname.new(project_path).realpath.to_s
       cleaner = Roger::Release::Cleaner.new(path)
 
-      inside_build_path = cleaner.send :inside_build_path?, path, @base + "/html/formats"
+      inside = cleaner.send :inside_build_path?, path, project_path + "html"
 
-      assert(inside_build_path, "Only delete content inside build_path")
+      assert(inside, "Only delete content inside build_path")
     end
 
     def test_dont_clean_outside_build_path
@@ -47,7 +52,7 @@ module Roger
       cleaner = Roger::Release::Cleaner.new(path)
 
       assert_raise RuntimeError do
-        cleaner.send :inside_build_path?, path, @base + "/html/formats"
+        cleaner.send :inside_build_path?, path, @release.project.path + "html"
       end
     end
 
@@ -56,19 +61,9 @@ module Roger
       cleaner = Roger::Release::Cleaner.new(path)
 
       assert(
-        !cleaner.send(:inside_build_path?, @base + "/html/formats", path),
+        !cleaner.send(:inside_build_path?, @release.project.path + "/html", path),
         "Failed on nonexistent directories/files"
       )
-    end
-
-    protected
-
-    def create_and_assert_directories(dirs)
-      dirs.each do |dir|
-        path = @base + "/" + dir
-        mkdir path unless File.directory?(path)
-        assert(File.directory?(path))
-      end
     end
   end
 end

--- a/test/unit/release/finalizers/zip_test.rb
+++ b/test/unit/release/finalizers/zip_test.rb
@@ -1,50 +1,31 @@
 require "test_helper"
-require "./lib/roger/release/finalizers/zip"
-require "mocha/test_unit"
-require "tmpdir"
+require "roger/testing/mock_release"
 
 module Roger
   # Test for Roger Zip finalizer
   class ZipTest < ::Test::Unit::TestCase
     def setup
-      # Mock git repo
-      @tmp_dir = Pathname.new(Dir.mktmpdir)
+      @release = Testing::MockRelease.new
 
-      project_path = @tmp_dir + "project"
-      FileUtils.mkdir(project_path)
+      # Create a file to release in the build dir
+      @release.project.construct.file "build/index.html"
 
-      @release_path = @tmp_dir + "releases"
-      FileUtils.mkdir(@release_path)
-
-      Dir.chdir(project_path) do
-        `git init`
-        `mkdir html`
-        `touch html/index.html`
-      end
-
-      # Mock release object
-      @release_mock = stub(project: stub(path: project_path))
-
-      @release_mock.stubs(
-        scm: stub(version: "1.0.0"),
-        log: true,
-        target_path: @release_path,
-        build_path: project_path + "html"
-      )
+      # Set fixed version
+      @release.scm.version = "1.0.0"
     end
 
     # called after every single test
     def teardown
-      FileUtils.rm_rf(@tmp_dir)
-      @release_mock = nil
+      @release.destroy
+      @release = nil
     end
 
     def test_basic_functionality
       finalizer = Roger::Release::Finalizers::Zip.new
 
-      finalizer.call(@release_mock)
+      finalizer.call(@release)
 
-      assert File.exist?(@release_path + "html-1.0.0.zip")
+      assert File.exist?(@release.target_path + "html-1.0.0.zip"), @release.target_path.inspect
     end
   end
 end

--- a/test/unit/release/processors/mockup_test.rb
+++ b/test/unit/release/processors/mockup_test.rb
@@ -1,14 +1,17 @@
 require "test_helper"
-require "./lib/roger/release"
+require "roger/testing/mock_release"
 
 module Roger
   # Test Roger Mockup
   class MockupTest < ::Test::Unit::TestCase
     def setup
-      @base = File.dirname(__FILE__) + "/../../../project"
-      @project = Roger::Project.new(@base)
-      @release = Roger::Release.new(@project)
+      @release = Testing::MockRelease.new
       @mockup = Roger::Release::Processors::Mockup.new
+    end
+
+    def teardown
+      @release.destroy
+      @release = nil
     end
 
     def test_empty_release_runs

--- a/test/unit/release/processors/url_relativizer_test.rb
+++ b/test/unit/release/processors/url_relativizer_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+require "roger/testing/mock_release"
+
+module Roger
+  # Test Roger Mockup
+  class UrlRelativizerTest < ::Test::Unit::TestCase
+    def setup
+      @release = Testing::MockRelease.new
+      @processor = Roger::Release::Processors::UrlRelativizer.new
+    end
+
+    def teardown
+      @release.destroy
+      @release = nil
+    end
+
+    def test_empty_release_runs
+      files = @processor.call(@release)
+      assert_equal 0, files.length
+    end
+
+    def test_basic_relativization
+      @release.project.construct.directory "build/sub" do |dir|
+        dir.file "test.html", "<a href='/test.html'>link</a>"
+      end
+      @release.project.construct.file "build/test.html"
+
+      files = @processor.call(@release)
+      assert_equal 2, files.length
+
+      contents = File.read((@release.build_path + "sub/test.html").to_s)
+      assert contents.include?("../test.html")
+    end
+  end
+end


### PR DESCRIPTION
This is an alternative implementation of #29

After discussion with @edwinvdgraaf I've come to the conclusion that the use of Mock objects that are subclasses of the actual objects have a lot of benefits. So I added an alternative to having subclasses of Test::Unit::TestCase. These can also be used outside of Roger in plugins for testing.

The module is called Testing which is a bit unintuitive but as Test is already taken by the Roger Test
we have to make due.

Let me know what you think!