### PR TITLE
[WIP] Proposal for guards in documentation

### DIFF
--- a/doc/rogerfile.md
+++ b/doc/rogerfile.md
@@ -29,6 +29,18 @@ roger.test do |t|
 end
 
 roger.release do |release|
+
+  # You can add global guards these wele stop the release process immediately
+  # if they are not fullfilled.
+  #
+  # required: parameter is optional and is true by default. If it's not true
+  # the guard is not required. Checks will still run. This is mostly useful in 
+  # situations where the guard output is needed in a block.
+  release.guard :tests, required: true
+
+  # Some more guards
+  release.guard :bower_dependencies
+  release.guard :npm_dependencies
   
   # The variables below can be used anywhere in this section
   release.target_path # The target path where releases are put
@@ -96,5 +108,23 @@ roger.release do |release|
   # Finalize the release
   # This is the default finalizer so not required
   # release.finalize :dir
+
+  # Let's add a more complicated guard with a block
+  # This type of guard will only guard the block not the whole
+  # release process.
+
+  # The guard below will check if the commandline flag `--skip-upload` is set
+  # the block will run (the guard is satisfied) if the `--skip-upload` flag is NOT present
+  release.guard :commandline_flag, flag: "skip-upload", satisfy_if: false do
+    release.finalize :rsync, :host => "mywebhost", :username => "myuser", :remote_path => "www"
+  end
+
+  # This guard will check for the `--always-upload` flag. It will run the
+  # inner block regardless of it's outcome. We can however use the guard to pass
+  # info from the guard to the block.I 
+  r.guard :commandline_flag, flag: "always-upload", required: false do |guard|
+    release.finalize :rsync, :host => "mywebhost", :username => "myuser", :remote_path => "www", :ask => !guard.flag
+  end 
+
 end
 ```


### PR DESCRIPTION
As we want to have more control over what get's applied and what not and we also want a way to ensure a sane build before we actually release it I propose that we build guards into the roger release process.

# How does it work?

A guard can work in 2 ways:

- It can stop execution of the release
- It can stop execution of a block (when used in block syntax)

There is one additional case where the guard can be used:

- It can pass the outcome of the guard condition to the block if the guard is not required to pass.

This last case is especially useful when we want to pass a condition to a finalizer/processor.

# Syntax

The basic syntax looks like this

```ruby
roger.release do |release|
  # Will abort release if guard is not satisfied
  release.guard :the_guard

  # Will not run block if guard is not satisfied
  release.guard :the_guard do 
    # ...
  end

  # Will always run block and pass guard including outcome to the block
  release.guard :the_guard, required: false do |guard|
    # ...
  end

  # Will abort release if guard IS satisfied
  release.guard :the_guard, satisfy_if: false
end
```

## Options

The guard command will have 2 default options:

* **Required**
  Wether or not the guard will abort the release or not run the passed block. 
  Default is `true`
* **Satisfy_if**
  What outcome should satisfy the guard. Can be handy to invert guard behaviour
  Default is `true`

# Writing guards

A guard again is nothing more than an object with a `call` method. That means you can pass lambda's as well. The only requirement is that it returns a truthy or falsy value.

# Proposed built-in guards

The follwing guards could be built-in Roger:

* **tests**
  A guard that is only satisfied when all of the roger tests run and succeed

* **commandline_flag**
  A guard that takes a `flag` option as string so you can pass this on the commandline when running `roger release`. Can also be very useful in combination with the `required: false` option.

    ```ruby
    roger.release do |release|
      release.guard :commandline_flag, flag: "always-upload", required: false do |guard|
        release.finalize :rsync, :host => "mywebhost", :username => "myuser", :remote_path => "www", :ask => !guard.flag
      end 
    end
    ```

# Future development

While the guards may be really useful in combination with release there are other scenario's where they could be helpfull in the test/server as well. In the test cases it could probably work just like in the release.

In the server scenario they will probably be run before the server starts, not on a request basis.