### PR TITLE
Add breaking testcase for failing resolving of urls with trialing slashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version NEXT
 * Change the way template resolving works so if you have a file and directory with the same basename it will prefer to use the file instead of looking for name/index.xyz
 * Add `content_for?(:xyz)` helper so you can check if a `content_for` block exists in templates.
+* Fix bug with resolving of trailing slashes.
 
 ## Version 1.5.1
 * Add MockShell object to stub out shell interactions. MockShell is also used by MockProject. This means all tests are silent on STDOUT/STDERR now.

--- a/lib/roger/resolver.rb
+++ b/lib/roger/resolver.rb
@@ -190,7 +190,7 @@ module Roger
     # Split path in to extension an path without extension
     def split_path(path)
       path = path.to_s
-      extension = File.extname(path)[1..-1]
+      extension = File.extname(path)[1..-1] || ""
       path_without_extension = path.sub(/\.#{Regexp.escape(extension)}\Z/, "")
       [extension, path_without_extension]
     end

--- a/test/unit/resolver_test.rb
+++ b/test/unit/resolver_test.rb
@@ -76,6 +76,10 @@ module Roger
       )
     end
 
+    def test_trailing_slashes_break
+      assert !@resolver.url_to_relative_url("/de/", "/")
+    end
+
     def test_path_to_url_relative_to_absolute_path
       assert_equal(
         @resolver.path_to_url(


### PR DESCRIPTION
See the following error:

```
TypeError: no implicit conversion of nil into String
/Users/edwin/Projects/zandbak/roger/lib/roger/resolver.rb:192:in `escape'
/Users/edwin/Projects/zandbak/roger/lib/roger/resolver.rb:192:in `split_path'
/Users/edwin/Projects/zandbak/roger/lib/roger/resolver.rb:128:in `find_template_path'
/Users/edwin/Projects/zandbak/roger/lib/roger/resolver.rb:55:in `block in find_template'
/Users/edwin/Projects/zandbak/roger/lib/roger/resolver.rb:53:in `each'
/Users/edwin/Projects/zandbak/roger/lib/roger/resolver.rb:53:in `find'
/Users/edwin/Projects/zandbak/roger/lib/roger/resolver.rb:53:in `find_template'
/Users/edwin/Projects/zandbak/roger/lib/roger/resolver.rb:84:in `url_to_relative_url'
/Users/edwin/Projects/zandbak/roger/test/unit/resolver_test.rb:80:in `test_trailing_slashes_break'
```