### PR TITLE
Update default template Gemfile source

### DIFF
--- a/examples/default_template/Gemfile
+++ b/examples/default_template/Gemfile
@@ -1,3 +1,3 @@
-source :rubygems
+source "https://rubygems.org/"
 
 gem "roger"


### PR DESCRIPTION
Current source produces a warning
>The source :rubygems is deprecated because HTTP requests are insecure.
>Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.