### PR TITLE
Implement content_for? helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version NEXT
 * Change the way template resolving works so if you have a file and directory with the same basename it will prefer to use the file instead of looking for name/index.xyz
+* Add `content_for?(:xyz)` helper so you can check if a `content_for` block exists in templates.
 
 ## Version 1.5.1
 * Add MockShell object to stub out shell interactions. MockShell is also used by MockProject. This means all tests are silent on STDOUT/STDERR now.

--- a/lib/roger/template/helpers/capture.rb
+++ b/lib/roger/template/helpers/capture.rb
@@ -25,6 +25,15 @@ module Roger
           @_content_for_blocks[block_name] = capture(&block)
         end
 
+        # Check if a block will yield content
+        #
+        # ```
+        #   <% if content_for? :name %> bla bla <% end %>
+        # ```
+        def content_for?(block_name)
+          (!_content_for_blocks[block_name].nil? && !_content_for_blocks[block_name].empty?)
+        end
+
         # rubocop:disable Lint/Eval
         def capture(&block)
           unless template.current_tilt_template == Tilt::ERBTemplate

--- a/test/unit/renderer/renderer_content_for_test.rb
+++ b/test/unit/renderer/renderer_content_for_test.rb
@@ -46,5 +46,21 @@ module Roger
 
       assert_equal "BAB-CONTENT-A", @renderer.render(@source_path, source: template_string)
     end
+
+    def test_content_for_check
+      # Is false when undefined
+      template = 'B<% if content_for? :one %><%= "one" %><% end %>A'
+      assert_equal "BA", @renderer.render(@source_path, source: template)
+
+      # Is false when empty
+      template =  "<% content_for :one do %><% end %>"
+      template << 'B<% if content_for? :one %><%= "one" %><% end %>A'
+      assert_equal "BA", @renderer.render(@source_path, source: template)
+
+      # Is true when set
+      template =  "<% content_for :one do %>one<% end %>"
+      template << "B<% if content_for? :one %><%= yield(:one) %><% end %>A"
+      assert_equal "BoneA", @renderer.render(@source_path, source: template)
+    end
   end
 end


### PR DESCRIPTION
Before this commit, checking wether a `content_for` block was set, it was required
to check the private `_content_for_blocks[:block_name]` variable in the
template. 

This additions adds a more elegant way of checking
`content_for?`.