### PR TITLE
Allow up to 10 levels deep of recursion

### DIFF
--- a/test/project/partials/test/max_depth.html.erb
+++ b/test/project/partials/test/max_depth.html.erb
@@ -1,0 +1,5 @@
+<% if depth < max_depth %>
+  <%= partial 'test/max_depth', locals: { depth: locals[:depth] + 1, max_depth: locals[:max_depth] } %>
+<% else %>
+  Stop! Hammertime!
+<% end %>

--- a/test/unit/renderer/renderer_partial_test.rb
+++ b/test/unit/renderer/renderer_partial_test.rb
@@ -81,6 +81,16 @@ module Roger
       end
     end
 
+    def test_partial_ten_max_depth_recursion
+      r = render_erb_template "<%= partial 'test/max_depth', locals: {depth: 0, max_depth: 10} %>"
+
+      assert_match(/Hammertime/, r)
+
+      assert_raise(ArgumentError) do
+        render_erb_template "<%= partial 'test/max_depth', locals: {depth: 0, max_depth: 11} %>"
+      end
+    end
+
     def render_erb_template(template)
       @renderer.render(@base + "html/partials/test.html.erb", source: template)
     end


### PR DESCRIPTION
While the `prevent_recursion!` is in general very usefull. Recursive
templates can be usefull for example with building menu that are made up
with nested lists. This changes supports up to 10 level deep nesting.