### PR TITLE
Give processors/finalizer names and custom options

### DIFF
--- a/lib/roger/helpers/registration.rb
+++ b/lib/roger/helpers/registration.rb
@@ -1,0 +1,33 @@
+module Roger
+  module Helpers
+    # Helper module to handle registration
+    module Registration
+      # Register a class with a name. The method can have the following signatures:
+      #
+      # def register(processor)
+      #
+      # and for legacy reasons:
+      #
+      # def register(name, processor)
+      #
+      # in the first case the processor must have a name class method.
+      def register(name, processor = nil)
+        if name.is_a?(Class)
+          processor = name
+          name = processor.name
+        end
+
+        type = to_s.split("::").last
+
+        fail ArgumentError, "#{type} name '#{name.inspect}' already in use" if map.key?(name)
+        fail ArgumentError, "Name must be a symbol" unless name.is_a?(Symbol)
+
+        map[name] = processor
+      end
+
+      def map
+        @_map ||= {}
+      end
+    end
+  end
+end

--- a/lib/roger/release.rb
+++ b/lib/roger/release.rb
@@ -1,6 +1,7 @@
 require File.dirname(__FILE__) + "/helpers/get_callable"
 require File.dirname(__FILE__) + "/helpers/get_files"
 require File.dirname(__FILE__) + "/helpers/logging"
+require File.dirname(__FILE__) + "/helpers/registration"
 
 require "shellwords"
 

--- a/lib/roger/release.rb
+++ b/lib/roger/release.rb
@@ -16,10 +16,6 @@ module Roger
 
     class << self
      include Roger::Helpers::GetCallable
-
-     def default_stack
-       []
-     end
     end
 
     # @option config [:git, :fixed] :scm The SCM to use (default = :git)
@@ -288,8 +284,6 @@ module Roger
     end
 
     def run_stack!
-      @stack = self.class.default_stack.dup if @stack.empty?
-
       # call all objects in @stack
       @stack.each do |task|
         if task.is_a?(Array)

--- a/lib/roger/release.rb
+++ b/lib/roger/release.rb
@@ -304,5 +304,5 @@ end
 require File.dirname(__FILE__) + "/release/scm"
 require File.dirname(__FILE__) + "/release/injector"
 require File.dirname(__FILE__) + "/release/cleaner"
-require File.dirname(__FILE__) + "/release/finalizers"
 require File.dirname(__FILE__) + "/release/processors"
+require File.dirname(__FILE__) + "/release/finalizers"

--- a/lib/roger/release/finalizers.rb
+++ b/lib/roger/release/finalizers.rb
@@ -1,19 +1,15 @@
 # The Finalizers will finalize the release. Finalizers can be used to
 # copy the release, zip the release or upload the release
 module Roger::Release::Finalizers
-  # Abstract base finalizer
-  class Base
-    def initialize(options = {})
-      @options = {}
-      @options.update(options) if options
-    end
-
-    def call(_release, _options = {})
-      fail ArgumentError, "Implement in subclass"
-    end
+  # Abstract base finalizer; This is practically the same as a processor
+  class Base < Roger::Release::Processors::Base
   end
 
-  def self.register(name, finalizer)
+  def self.register(name, finalizer = nil)
+    if name.is_a?(Class)
+      finalizer = name
+      name = finalizer.name
+    end
     fail ArgumentError, "Finalizer name '#{name.inspect}' already in use" if map.key?(name)
     fail ArgumentError, "Name must be a symbol" unless name.is_a?(Symbol)
     map[name] = finalizer

--- a/lib/roger/release/finalizers.rb
+++ b/lib/roger/release/finalizers.rb
@@ -1,22 +1,10 @@
 # The Finalizers will finalize the release. Finalizers can be used to
 # copy the release, zip the release or upload the release
 module Roger::Release::Finalizers
+  extend Roger::Helpers::Registration
+
   # Abstract base finalizer; This is practically the same as a processor
   class Base < Roger::Release::Processors::Base
-  end
-
-  def self.register(name, finalizer = nil)
-    if name.is_a?(Class)
-      finalizer = name
-      name = finalizer.name
-    end
-    fail ArgumentError, "Finalizer name '#{name.inspect}' already in use" if map.key?(name)
-    fail ArgumentError, "Name must be a symbol" unless name.is_a?(Symbol)
-    map[name] = finalizer
-  end
-
-  def self.map
-    @_map ||= {}
   end
 end
 

--- a/lib/roger/release/finalizers/dir.rb
+++ b/lib/roger/release/finalizers/dir.rb
@@ -6,17 +6,20 @@ module Roger::Release::Finalizers
   # The directory name will have the format PREFIX-VERSION
   #
   class Dir < Base
+    self.name = :dir
+
     # @option options :prefix Prefix to put before the version (default = "html")
-    def call(release, call_options = {})
-      options = {
+    def default_options
+      {
         prefix: "html",
         target_path: release.target_path
-      }.update(@options)
-      options.update(call_options) if call_options
+      }
+    end
 
-      name = [options[:prefix], release.scm.version].join("-")
+    def perform
+      name = [@options[:prefix], @release.scm.version].join("-")
 
-      target_dir = Pathname.new(options[:target_path])
+      target_dir = Pathname.new(@options[:target_path])
       FileUtils.mkdir_p(target_dir) unless target_dir.exist?
 
       target_path = target_dir + name
@@ -33,4 +36,4 @@ module Roger::Release::Finalizers
   end
 end
 
-Roger::Release::Finalizers.register(:dir, Roger::Release::Finalizers::Dir)
+Roger::Release::Finalizers.register(Roger::Release::Finalizers::Dir)

--- a/lib/roger/release/finalizers/git_branch.rb
+++ b/lib/roger/release/finalizers/git_branch.rb
@@ -55,15 +55,15 @@ module Roger::Release::Finalizers
       ::Dir.chdir(clone_dir) do
         # 3. Copy changes
         FileUtils.rm_rf("*")
-        FileUtils.cp_r release.build_path.to_s + "/.", clone_dir.to_s
+        FileUtils.cp_r @release.build_path.to_s + "/.", clone_dir.to_s
 
         commands = [
           %w(git add .), # 4. Add all files
-          %w(git commit -a -m) << "Release #{release.scm.version}" # 5. Commit
+          %w(git commit -a -m) << "Release #{@release.scm.version}" # 5. Commit
         ]
 
         # 6. Git push if in options
-        commands << (%w(git push origin) << branch) if options[:push]
+        commands << (%w(git push origin) << branch) if @options[:push]
 
         commands.each do |command|
           `#{Shellwords.join(command)}`

--- a/lib/roger/release/finalizers/rsync.rb
+++ b/lib/roger/release/finalizers/rsync.rb
@@ -54,8 +54,8 @@ module Roger::Release::Finalizers
 
     def rsync(command, local_path, remote_path)
       target_path = remote_path
-      target_path = "#{options[:host]}:#{target_path}" if options[:host]
-      target_path = "#{options[:username]}@#{target_path}" if options[:username]
+      target_path = "#{@options[:host]}:#{target_path}" if @options[:host]
+      target_path = "#{@options[:username]}@#{target_path}" if @options[:username]
 
       command = [
         options[:rsync],
@@ -73,15 +73,15 @@ module Roger::Release::Finalizers
 
     def prompt_for_upload
       !options[:ask] ||
-        (prompt("Do you wish to upload to #{options[:host]}? [y/N]: ")) =~ /\Ay(es)?\Z/
+        prompt("Do you wish to upload to #{@options[:host]}? [y/N]: ") =~ /\Ay(es)?\Z/
     end
 
     def validate_options!
       must_have_keys = [:remote_path]
-      return if (options.keys & must_have_keys).size == must_have_keys.size
+      return if (@options.keys & must_have_keys).size == must_have_keys.size
 
-      release.log(self, "Missing options: #{(must_have_keys - options.keys).inspect}")
-      fail "Missing keys: #{(must_have_keys - options.keys).inspect}"
+      release.log(self, "Missing options: #{(must_have_keys - @options.keys).inspect}")
+      fail "Missing keys: #{(must_have_keys - @options.keys).inspect}"
     end
 
     def prompt(question = "Do you wish to continue?")

--- a/lib/roger/release/finalizers/zip.rb
+++ b/lib/roger/release/finalizers/zip.rb
@@ -1,34 +1,34 @@
 module Roger::Release::Finalizers
   # The zip finalizer
-  # The zip finalizer will
   class Zip < Base
-    attr_reader :release
+    self.name = :zip
 
     # @option options [String] :prefix Prefix to put before the version (default = "html")
     # @option options [String] :zip The zip command
     # @option options [String, Pathname] :target_path (release.target_path) The path to zip to
-    def call(release, call_options = {})
-      options = {
+
+    def default_options
+      {
         zip: "zip",
         prefix: "html",
         target_path: release.target_path
-      }.update(@options)
+      }
+    end
 
-      options.update(call_options) if call_options
+    def perform
+      target_path = ensure_target_path(@options[:target_path])
 
-      target_path = ensure_target_path(options[:target_path])
-
-      name = [options[:prefix], release.scm.version].join("-") + ".zip"
+      name = [options[:prefix], @release.scm.version].join("-") + ".zip"
       zip_path = target_path + name
 
-      release.log(self, "Finalizing release to #{zip_path}")
+      @release.log(self, "Finalizing release to #{zip_path}")
 
-      cleanup_existing_zip(release, zip_path)
+      cleanup_existing_zip(zip_path)
 
-      check_zip_command(options[:zip])
+      check_zip_command(@options[:zip])
 
-      ::Dir.chdir(release.build_path) do
-        `#{options[:zip]} -r -9 "#{zip_path}" ./*`
+      ::Dir.chdir(@release.build_path) do
+        `#{@options[:zip]} -r -9 "#{zip_path}" ./*`
       end
     end
 
@@ -40,7 +40,7 @@ module Roger::Release::Finalizers
       target_path
     end
 
-    def cleanup_existing_zip(release, path)
+    def cleanup_existing_zip(path)
       return unless File.exist?(path)
 
       release.log(self, "Removing existing target #{path}")
@@ -54,4 +54,4 @@ module Roger::Release::Finalizers
     end
   end
 end
-Roger::Release::Finalizers.register(:zip, Roger::Release::Finalizers::Zip)
+Roger::Release::Finalizers.register(Roger::Release::Finalizers::Zip)

--- a/lib/roger/release/processors.rb
+++ b/lib/roger/release/processors.rb
@@ -1,5 +1,7 @@
 # Processors can perform any action on a release
 module Roger::Release::Processors
+  extend Roger::Helpers::Registration
+
   # Abstract Processor class
   class Base
     attr_reader :options, :release
@@ -49,20 +51,6 @@ module Roger::Release::Processors
     def perform
       fail ArgumentError, "Implement in subclass"
     end
-  end
-
-  def self.register(name, processor = nil)
-    if name.is_a?(Class)
-      processor = name
-      name = processor.name
-    end
-    fail ArgumentError, "Processor name '#{name.inspect}' already in use" if map.key?(name)
-    fail ArgumentError, "Name must be a symbol" unless name.is_a?(Symbol)
-    map[name] = processor
-  end
-
-  def self.map
-    @_map ||= {}
   end
 end
 

--- a/lib/roger/release/processors.rb
+++ b/lib/roger/release/processors.rb
@@ -1,30 +1,70 @@
-module Roger
-  class Release
-    # The Processors namespace
-    module Processors
-      # Abstract Processor class
-      class Base
-        def initialize(options = {})
-          @options = {}
-          @options.update(options) if options
-        end
+# Processors can perform any action on a release
+module Roger::Release::Processors
+  # Abstract Processor class
+  class Base
+    attr_reader :options, :release
 
-        def call(_release, _options = {})
-          fail ArgumentError, "Implement in subclass"
-        end
-      end
+    class << self
+      attr_writer :name
 
-      def self.register(name, processor)
-        fail ArgumentError, "Processor name '#{name.inspect}' already in use" if map.key?(name)
-        fail ArgumentError, "Name must be a symbol" unless name.is_a?(Symbol)
-        map[name] = processor
-      end
-
-      def self.map
-        @_map ||= {}
+      # Name of this processor
+      def name
+        @name || fail(ArgumentError, "Implement in subclass")
       end
     end
+
+    # Default options for this processor
+    def default_options
+      {}
+    end
+
+    # Name of this processor.
+    # - Can be set by setting the :name config in the release block
+    # - Can be overwritten in implementation if needed
+    def name
+      options && options[:name] || self.class.name
+    end
+
+    def call(release, options = {})
+      @release = release
+      @options = {}.update(default_options)
+      @options.update(options) if options
+      @options.update(my_project_options)
+
+      # Stop immideatly if we've been disabled
+      return if @options[:disable]
+
+      perform
+    end
+
+    protected
+
+    # The options passed through the project. This can contain
+    # command line options
+    def my_project_options
+      project_options = release.project.options
+      project_options[:release] && project_options[:release][name] || {}
+    end
+
+    def perform
+      fail ArgumentError, "Implement in subclass"
+    end
+  end
+
+  def self.register(name, processor = nil)
+    if name.is_a?(Class)
+      processor = name
+      name = processor.name
+    end
+    fail ArgumentError, "Processor name '#{name.inspect}' already in use" if map.key?(name)
+    fail ArgumentError, "Name must be a symbol" unless name.is_a?(Symbol)
+    map[name] = processor
+  end
+
+  def self.map
+    @_map ||= {}
   end
 end
+
 require File.dirname(__FILE__) + "/processors/mockup"
 require File.dirname(__FILE__) + "/processors/url_relativizer"

--- a/lib/roger/release/processors/mockup.rb
+++ b/lib/roger/release/processors/mockup.rb
@@ -39,7 +39,7 @@ module Roger::Release::Processors
         # in the roger.base_path
         next if File.basename(file_path).start_with? "_"
 
-        self.run_on_file!(file_path, @options[:env])
+        run_on_file!(file_path, @options[:env])
       end
     end
 

--- a/lib/roger/release/processors/mockup.rb
+++ b/lib/roger/release/processors/mockup.rb
@@ -95,9 +95,9 @@ module Roger::Release::Processors
     def log_call
       release.log(self, "Processing mockup files")
 
-      release.log(self, "  Matching: #{options[:match].inspect}", true)
-      release.log(self, "  Skiping : #{options[:skip].inspect}", true)
-      release.log(self, "  Env     : #{options[:env].inspect}", true)
+      release.log(self, "  Matching: #{@options[:match].inspect}", true)
+      release.log(self, "  Skiping : #{@options[:skip].inspect}", true)
+      release.log(self, "  Env     : #{@options[:env].inspect}", true)
       release.log(self, "  Files   :", true)
     end
   end

--- a/lib/roger/release/processors/url_relativizer.rb
+++ b/lib/roger/release/processors/url_relativizer.rb
@@ -6,20 +6,18 @@ module Roger::Release::Processors
   # The relativizer can be used to rewrite absolute paths in attributes to relative paths
   # during release.
   class UrlRelativizer < Base
-    def initialize(options = {})
-      @options = {
+    self.name = :url_relativizer
+
+    def default_options
+      {
         url_attributes: %w(src href action),
         match: ["**/*.html"],
         skip: []
       }
-
-      @options.update(options) if options
     end
 
-    def call(release, options = {})
-      options = {}.update(@options).update(options)
-
-      log_call(release, options)
+    def perform
+      log_call
 
       @resolver = Roger::Resolver.new(release.build_path)
 
@@ -32,10 +30,10 @@ module Roger::Release::Processors
 
     protected
 
-    def log_call(release, options)
-      log_message = "Relativizing all URLS in #{options[:match].inspect}"
-      log_message << "files in attributes #{options[:url_attributes].inspect},"
-      log_message << "skipping #{options[:skip].any? ? options[:skip].inspect : 'none' }"
+    def log_call
+      log_message = "Relativizing all URLS in #{@options[:match].inspect}"
+      log_message << "files in attributes #{@options[:url_attributes].inspect},"
+      log_message << "skipping #{@options[:skip].any? ? @options[:skip].inspect : 'none' }"
       release.log(self, log_message)
     end
 
@@ -73,4 +71,4 @@ module Roger::Release::Processors
   end
 end
 
-Roger::Release::Processors.register(:url_relativizer, Roger::Release::Processors::UrlRelativizer)
+Roger::Release::Processors.register(Roger::Release::Processors::UrlRelativizer)

--- a/lib/roger/release/processors/url_relativizer.rb
+++ b/lib/roger/release/processors/url_relativizer.rb
@@ -33,7 +33,7 @@ module Roger::Release::Processors
     def log_call
       log_message = "Relativizing all URLS in #{@options[:match].inspect}"
       log_message << "files in attributes #{@options[:url_attributes].inspect},"
-      log_message << "skipping #{@options[:skip].any? ? @options[:skip].inspect : 'none' }"
+      log_message << "skipping #{@options[:skip].any? ? @options[:skip].inspect : 'none'}"
       release.log(self, log_message)
     end
 

--- a/test/unit/release/finalizers/rsync_test.rb
+++ b/test/unit/release/finalizers/rsync_test.rb
@@ -27,25 +27,27 @@ module Roger
     end
 
     def test_basic_functionality
-      finalizer = Roger::Release::Finalizers::Rsync.new(
+      finalizer = Roger::Release::Finalizers::Rsync.new
+
+      finalizer.call(
+        @release,
         remote_path: @target_path.to_s,
         ask: false
       )
-
-      finalizer.call(@release)
 
       assert File.exist?(@target_path + "index.html"), @release.target_path.inspect
     end
 
     def test_rsync_command_works
-      finalizer = Roger::Release::Finalizers::Rsync.new(
-        rsync: "rsync-0123456789", # Let's hope nobody actually has this command
-        remote_path: @target_path.to_s,
-        ask: false
-      )
+      finalizer = Roger::Release::Finalizers::Rsync.new
 
       assert_raise(RuntimeError) do
-        finalizer.call(@release)
+        finalizer.call(
+          @release,
+          rsync: "rsync-0123456789", # Let's hope nobody actually has this command
+          remote_path: @target_path.to_s,
+          ask: false
+        )
       end
     end
   end

--- a/test/unit/release_test.rb
+++ b/test/unit/release_test.rb
@@ -33,14 +33,13 @@ module Roger
       @project.release.run!
 
       assert @project.release.stack.empty?
-      assert @project.release.finalizers.empty?
     end
 
     def test_release_should_add_mockup_processor_as_first_by_default
       release = @rogerfile.release
       release.run!
 
-      assert release.stack.length > 0
+      assert !release.stack.empty?
       assert_equal Roger::Release::Processors::Mockup, release.stack.first.first.class
     end
 
@@ -48,8 +47,16 @@ module Roger
       release = @rogerfile.release
       release.run!
 
-      assert release.stack.length > 0
-      assert_equal Roger::Release::Processors::UrlRelativizer, release.stack.last.first.class
+      assert !release.stack.empty?
+      assert_equal Roger::Release::Processors::UrlRelativizer, release.stack[-2].first.class
+    end
+
+    def test_release_should_add_dir_finalizer_by_default
+      release = @rogerfile.release
+      release.run!
+
+      assert !release.stack.empty?
+      assert_equal Roger::Release::Finalizers::Dir, release.stack.last.first.class
     end
 
     #  =============================


### PR DESCRIPTION
This is a pre-cursor to allow setting options through the commandline. In this pull request the following changes:

1. Finalizers no longer have a separate stack in the release process. This means everything will be executed in order as it's defined (`r.use` and `r.finalize`)

Finalizers and processors:

1. ...now use the same Base code
1. ...now now about their identity
1. ...can have per-instance names, this means you can identify multiple `r.finalize`/`r.use` calls by passing them the `:name` option
1. ...will merge project options into their own options under `project.options[:release][self.name]`
1. ...can be disabled through the `:disable` option