### PR TITLE
Limit rack application file handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Edge
+* Roger Rack application now adheres to match/skip options. Pass them in the rogerfile as follows:
+    ```
+    roger.server do |s|
+      s.application_options = { match: [], skip: [] }
+    end
+    ```
+
 ## Version 1.7.2
 * Return from partials instead of rendering partial content as string. This allows us to have code in ruby blocks instead of just more ERB.
 

--- a/doc/rogerfile.md
+++ b/doc/rogerfile.md
@@ -21,6 +21,8 @@ Sass::Plugin.options[:css_location] = "./html/stylesheets"
 # Server is a regular Rack interface.
 roger.serve do |server|
   server.use :sass
+
+  server.application_options = {match: ["**/*.html.erb"]} # Config for Rack application (call is optional)
 end
 
 # Define tests

--- a/lib/roger/helpers/get_files.rb
+++ b/lib/roger/helpers/get_files.rb
@@ -2,18 +2,34 @@ module Roger
   module Helpers
     # Helper to include the get_files method
     module GetFiles
+      GLOB_OPTIONS = File::FNM_PATHNAME | File::FNM_EXTGLOB | File::FNM_DOTMATCH
+
       # Get files from a path, skipping excludes.
       #
       # @param [Array] globs an array of file path globs that will be globbed
       #                against the project path
       # @param [Array] excludes an array of regexps[!] that will be excluded
       #                from the result.
-      # @param [String, Pathname] Path to search files in
-      def get_files(globs, excludes = [], path = nil)
+      def get_files(globs, excludes = [])
         path = Pathname.new(get_files_default_path)
-        files = globs.map { |g| Dir.glob(path + g) }.flatten
+        files = globs.map { |g| Dir.glob(path + g, GLOB_OPTIONS) }.flatten
         files.reject! { |file| excludes.detect { |e| file.match(e) } } if excludes.any?
         files.select { |file| File.file?(file) }
+      end
+
+      # See if a file matches globs/excludes
+      #
+      # @param [.to_s] path the path to match
+      # @param [Array] globs an array of file path globs that will be matched against path
+      # @param [Array] exclude an array of regexps[!] that will be matched negatively against path
+      #
+      # @return [Boolean] Did the passed path match against the globs and excludes?
+      def match_path(path, globs, excludes = [])
+        path = path.to_s
+        match = globs.detect { |glob| File.fnmatch?(glob, path, GLOB_OPTIONS) }
+        return false unless match # No need to check excludes if we don't match anyway
+
+        !excludes.find { |e| path.match(e) }
       end
 
       protected

--- a/lib/roger/rack/roger.rb
+++ b/lib/roger/rack/roger.rb
@@ -23,7 +23,8 @@ module Roger
         url = env["PATH_INFO"]
         env["MOCKUP_PROJECT"] = env["roger.project"] || @project
 
-        if template_path = @resolver.url_to_path(url)
+        template_path = @resolver.url_to_path(url)
+        if template_path && ::Roger::Renderer.will_render?(template_path)
           env["rack.errors"].puts "Rendering template #{template_path.inspect} (#{url.inspect})"
           build_response(template_path, env).finish
         else

--- a/lib/roger/rack/roger.rb
+++ b/lib/roger/rack/roger.rb
@@ -10,7 +10,7 @@ module Roger
     # Roger middleware that processe roger templates
     class Roger
       include ::Roger::Helpers::GetFiles
-      attr_reader :project
+      attr_reader :project, :options
 
       def default_options
         {

--- a/lib/roger/rack/roger.rb
+++ b/lib/roger/rack/roger.rb
@@ -43,6 +43,7 @@ module Roger
         mime = ::Rack::Mime.mime_type(File.extname(template_path), "text/html")
         ::Rack::Response.new do |res|
           res.headers["Content-Type"] = mime if mime
+          res.headers["X-Handled-By"] = "Roger"
           res.status = 200
           res.write renderer.render(template_path, @project.options[:renderer] || {})
         end

--- a/lib/roger/rack/roger.rb
+++ b/lib/roger/rack/roger.rb
@@ -9,10 +9,24 @@ module Roger
   module Rack
     # Roger middleware that processe roger templates
     class Roger
+      include ::Roger::Helpers::GetFiles
       attr_reader :project
 
-      def initialize(project)
+      def default_options
+        {
+          match: ["**/*.{html,md,html.erb}"],
+          skip: []
+        }
+      end
+
+      # Initialize the Rack app
+      #
+      # @param [Hash] options Options to use
+      #
+      # @option options
+      def initialize(project, options = {})
         @project = project
+        @options = default_options.update(options)
         @docroot = project.html_path
 
         @resolver = Resolver.new(@docroot)
@@ -24,7 +38,7 @@ module Roger
         env["MOCKUP_PROJECT"] = env["roger.project"] || @project
 
         template_path = @resolver.url_to_path(url)
-        if template_path && ::Roger::Renderer.will_render?(template_path)
+        if process_path_by_roger?(template_path)
           env["rack.errors"].puts "Rendering template #{template_path.inspect} (#{url.inspect})"
           build_response(template_path, env).finish
         else
@@ -34,6 +48,16 @@ module Roger
       end
 
       protected
+
+      # Wether or not we should process this
+      # path by the Roger renderer.
+      def process_path_by_roger?(path)
+        return false unless path
+
+        return false unless match_path(path, @options[:match], @options[:skip])
+
+        ::Roger::Renderer.will_render?(path)
+      end
 
       def build_response(template_path, env)
         renderer = ::Roger::Renderer.new(

--- a/lib/roger/renderer.rb
+++ b/lib/roger/renderer.rb
@@ -22,7 +22,7 @@ module Roger
         @helpers || []
       end
 
-      # Will the renderer render this path to something meaningfull?
+      # Will the renderer render this path to something meaningful?
       def will_render?(path)
         Tilt.templates_for(path.to_s).any?
       end

--- a/lib/roger/renderer.rb
+++ b/lib/roger/renderer.rb
@@ -22,6 +22,11 @@ module Roger
         @helpers || []
       end
 
+      # Will the renderer render this path to something meaningfull?
+      def will_render?(path)
+        Tilt.templates_for(path.to_s).any?
+      end
+
       # Try to infer the final extension of the output file.
       def target_extension_for(path)
         if type = MIME::Types[target_mime_type_for(path)].first

--- a/lib/roger/server.rb
+++ b/lib/roger/server.rb
@@ -28,6 +28,11 @@ module Roger
 
     attr_accessor :port, :handler, :host, :auto_port
 
+    # @attr_accessor [Hash] Options pass to ::Roger::Rack::Roger initialization
+    #
+    # @see ::Roger::Rack:Roger
+    attr_accessor :application_options
+
     def initialize(project, options = {})
       @project = project
 
@@ -143,7 +148,7 @@ module Roger
     def application
       return @app if @app
 
-      @stack.run Rack::Roger.new(project)
+      @stack.run Rack::Roger.new(project, @application_options || {})
 
       @app = @stack
     end

--- a/test/unit/helpers/get_files_test.rb
+++ b/test/unit/helpers/get_files_test.rb
@@ -34,6 +34,7 @@ module Roger
       files = [
         "a.js",
         "1.js",
+        "2.js",
         "1.html",
         "dir/2.js",
         "dir/3.js",
@@ -55,6 +56,12 @@ module Roger
       assert_array_contains(expect, files)
     end
 
+    def test_glob_extended
+      files = @object.get_files(["**/{1,2}.js"])
+      expect = @files.grep(/[12]\.js\Z/)
+      assert_array_contains(expect, files)
+    end
+
     def test_get_only_files
       dir = @object.construct.directory "evil.js"
       files = @object.get_files(["*.js"])
@@ -65,6 +72,34 @@ module Roger
       files = @object.get_files(["**/*.js"], ["\Adir"])
       expect = @files.grep(/\.js\Z/).reject { |f| f.start_with?("dir") }
       assert_array_contains(expect, files)
+    end
+
+    def test_match_path_with_glob_in_root
+      path = "file.js"
+      assert @object.match_path(path, ["*"])
+      assert @object.match_path(path, ["**/*"])
+      assert @object.match_path(path, ["**/*.js"])
+    end
+
+    def test_match_path_with_glob_in_subdir
+      path = "dir/subdir/4.js"
+      assert !@object.match_path(path, [])
+      assert !@object.match_path(path, ["*"])
+      assert @object.match_path(path, ["**/*"])
+      assert @object.match_path(path, ["**/*.js"])
+      assert !@object.match_path(path, ["**/*.html"])
+      assert @object.match_path(path, ["**/*.html", "**/*.js"])
+    end
+
+    def test_match_path_with_extended_glob
+      assert @object.match_path("4.js", ["{3,4}.js"])
+      assert !@object.match_path("4.js", ["{5}.js"])
+    end
+
+    def test_match_path_with_excludes
+      path = "dir/subdir/4.js"
+      assert @object.match_path(path, ["**/*"], [/\.html\Z/])
+      assert !@object.match_path(path, ["**/*"], [/\.js\Z/])
     end
 
     protected

--- a/test/unit/rack/roger_test.rb
+++ b/test/unit/rack/roger_test.rb
@@ -31,6 +31,15 @@ module Roger
         assert_equal nil, response.headers["X-Handled-By"]
       end
 
+      def test_middleware_does_not_render_unwanteds
+        @project.construct.file "html/mysass.scss", ".scss{}"
+        request = ::Rack::MockRequest.new(@app)
+        response = request.get("/mysass.scss")
+
+        assert response.body.include?(".scss{}")
+        assert_equal nil, response.headers["X-Handled-By"]
+      end
+
       def test_renderer_options_are_passed
         @project.options[:renderer][:layout] = {
           "html.erb" => "bracket"

--- a/test/unit/rack/roger_test.rb
+++ b/test/unit/rack/roger_test.rb
@@ -19,6 +19,8 @@ module Roger
         response = request.get("/erb")
 
         assert response.body.include?("ERB format")
+        assert_equal "Roger", response.headers["X-Handled-By"]
+      end
       end
 
       def test_renderer_options_are_passed

--- a/test/unit/rack/roger_test.rb
+++ b/test/unit/rack/roger_test.rb
@@ -21,6 +21,14 @@ module Roger
         assert response.body.include?("ERB format")
         assert_equal "Roger", response.headers["X-Handled-By"]
       end
+
+      def test_middleware_does_not_render_unrenderables
+        @project.construct.file "html/myjpeg.jpg", "JPG"
+        request = ::Rack::MockRequest.new(@app)
+        response = request.get("/myjpeg.jpg")
+
+        assert response.body.include?("JPG")
+        assert_equal nil, response.headers["X-Handled-By"]
       end
 
       def test_renderer_options_are_passed

--- a/test/unit/server_test.rb
+++ b/test/unit/server_test.rb
@@ -59,5 +59,26 @@ module Roger
       # This is a bit of a clunky comparison but it suffices for now
       assert_equal @project.object_id.to_s, request.get("/").body
     end
+
+    def test_application_options
+      @server.application_options = { test_option: true }
+
+      test = Class.new do
+        def initialize(app)
+          @app = app
+        end
+
+        def call(_env)
+          [200, {}, [@app.options[:test_option].to_s]]
+        end
+      end
+
+      @server.use test
+
+      request = ::Rack::MockRequest.new(@server.send(:application))
+
+      # This is a bit of a clunky comparison but it suffices for now
+      assert_equal "true", request.get("/").body
+    end
   end
 end


### PR DESCRIPTION
Fixes #74 

It contains 2 parts:

1) Do not process unrenderable templates (why would we??)
2) Introduce match/skip options for the rack app, just like we can do in the processor.