### PR TITLE
Render all erb files in serve mode by default

### DIFF
--- a/lib/roger/rack/roger.rb
+++ b/lib/roger/rack/roger.rb
@@ -14,7 +14,7 @@ module Roger
 
       def default_options
         {
-          match: ["**/*.{html,md,html.erb}"],
+          match: ["**/*.{html,md,erb}"],
           skip: []
         }
       end


### PR DESCRIPTION
Some projects have files with extensions such as `.json.erb` which now work again.